### PR TITLE
Expect config file template in cmake/ directory rather than src/

### DIFF
--- a/cmake/beman-install-library-config.cmake
+++ b/cmake/beman-install-library-config.cmake
@@ -121,7 +121,7 @@ function(beman_install_library name)
         find_file(
             config_file_template
             NAMES "${package_name}-config.cmake.in"
-            PATHS "${CMAKE_CURRENT_SOURCE_DIR}"
+            PATHS "${PROJECT_SOURCE_DIR}/cmake"
             NO_DEFAULT_PATH
             NO_CACHE
             REQUIRED


### PR DESCRIPTION
This is the new pattern for Beman libraries and allows us to support both header-only and source-based libraries.