### PR TITLE
Fix incorrect default for project_INSTALL_CONFIG_FILE_PACKAGE

### DIFF
--- a/cmake/beman-install-library-config.cmake
+++ b/cmake/beman-install-library-config.cmake
@@ -84,8 +84,8 @@ function(beman_install_library name)
 
     option(
         ${project_prefix}_INSTALL_CONFIG_FILE_PACKAGE
-        "Enable building examples. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
-        ${PROJECT_IS_TOP_LEVEL}
+        "Enable creating and installing a CMake config-file package. Default: ON. Values: { ON, OFF }."
+        ON
     )
 
     # By default, install the config package


### PR DESCRIPTION
The default for this option was supposed to be set to ON by https://github.com/bemanproject/exemplar/commit/19d99a467d2bbd9fde1ad08ea5565f1cc0b34b73, hence the commit title "Default generation of CMake config packages to ON". However, due to what I believe is a copypaste bug, that commit set the default to ${PROJECT_IS_TOP_LEVEL} rather than ON, which broke the ability to consume Beman libraries as dependencies. This commit changes the default to ON, which has been tested to address the issue. It also fixes the doc.