### PR TITLE
Add workaround for Catch2 to use-fetch-content.cmake

### DIFF
--- a/cmake/use-fetch-content.cmake
+++ b/cmake/use-fetch-content.cmake
@@ -170,6 +170,18 @@ function(BemanExemplar_provideDependency method package_name)
                 set(INSTALL_GTEST OFF) # Disable GoogleTest installation
                 FetchContent_MakeAvailable("${BemanExemplar_name}")
 
+                # Catch2's CTest integration module isn't on CMAKE_MODULE_PATH
+                # when brought in via FetchContent. Add it so that
+                # `include(Catch)` works.
+                if(BemanExemplar_pkgName STREQUAL "Catch2")
+                    list(
+                        APPEND
+                        CMAKE_MODULE_PATH
+                        "${${BemanExemplar_name}_SOURCE_DIR}/extras"
+                    )
+                    set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
+                endif()
+
                 # Important! <PackageName>_FOUND tells CMake that `find_package` is
                 # not needed for this package anymore
                 set("${BemanExemplar_pkgName}_FOUND" TRUE PARENT_SCOPE)


### PR DESCRIPTION
Previously, when the library was brought in via FetchContent, users would need to add this line:

list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)

This commit isolates the workaround to use-fetch-content.cmake, as it's not needed when Catch2 is installed on the system or brought in via another, non-FetchContent-based method.