### PR TITLE
Adjust CMake messages for build telemetry

### DIFF
--- a/cmake/BuildTelemetryConfig.cmake
+++ b/cmake/BuildTelemetryConfig.cmake
@@ -4,15 +4,15 @@ set(BUILD_TELEMETRY_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 function(configure_build_telemetry)
     if(NOT BUILD_TELEMETRY_CONFIGURATION)
-        message(STATUS "Configuring Build Telemetry")
-
         # Check if the CMake version is at least 4.3
         if(CMAKE_VERSION VERSION_LESS "4.3")
             message(
-                WARNING
+                STATUS
                 "CMake version is less than 4.3, configuring cmake_instrumentation is unavailable."
             )
             return()
+        else()
+            message(STATUS "Configuring Build Telemetry")
         endif()
 
         # Telemetry query
@@ -25,7 +25,7 @@ function(configure_build_telemetry)
           CALLBACK ${BUILD_TELEMETRY_DIR}/telemetry.sh
         )
         message(
-            WARNING
+            DEBUG
             "using callback script ${BUILD_TELEMETRY_DIR}/telemetry.sh"
         )
 


### PR DESCRIPTION
Previously, if a user was running a build on a version of CMake less than 4.3, they would get this message:

```
-- Configuring Build Telemetry
CMake Warning at infra/cmake/BuildTelemetryConfig.cmake:11 (message):
  CMake version is less than 4.3, configuring cmake_instrumentation is
  unavailable.
Call Stack (most recent call first):
  CMakeLists.txt:47 (configure_build_telemetry)
```

Furthermore, if they were running with CMake 4.3, they would get this message:

```
-- Configuring Build Telemetry
CMake Warning at infra/cmake/BuildTelemetryConfig.cmake:27 (message):
  using callback script
  /home/eddie/sync/cpp/bemanproject/exemplar/infra/cmake/telemetry.sh
Call Stack (most recent call first):
  CMakeLists.txt:47 (configure_build_telemetry)
```

Both of these are warnings, which is the wrong mode here because in neither case is there any real sense in which the user has done something wrong.

This commit adjusts these messages so that "Configuring Build Telemetry" only prints if the version is at least 4.3, the "configuring cmake_instrumentation is unavailable" message is a STATUS message rather than a WARNING, and the "using callback script" message is a DEBUG message.