### PR TITLE
Update gersemi pre-commit hook to new repository and bump codespell version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ repos:
     -   id: check-added-large-files
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.2
     hooks:
       - id: codespell
 
     # CMake linting and formatting
-  - repo: https://github.com/BlankSpruce/gersemi
-    rev: 0.22.3
+  - repo: https://github.com/BlankSpruce/gersemi-pre-commit
+    rev: 0.27.2
     hooks:
     - id: gersemi
       name: CMake linting

--- a/cmake/BuildTelemetryConfig.cmake
+++ b/cmake/BuildTelemetryConfig.cmake
@@ -29,12 +29,19 @@ function(configure_build_telemetry)
 
         # Telemetry query
         cmake_instrumentation(
-          API_VERSION 1
-          DATA_VERSION 1
-
-          OPTIONS staticSystemInformation dynamicSystemInformation trace
-          HOOKS postGenerate preBuild postBuild preCMakeBuild postCMakeBuild postCMakeInstall postCTest
-          CALLBACK ${BEMAN_BASH} ${BUILD_TELEMETRY_DIR}/telemetry.sh
+            API_VERSION 1
+            DATA_VERSION 1
+            OPTIONS staticSystemInformation dynamicSystemInformation trace
+            HOOKS
+                postGenerate
+                preBuild
+                postBuild
+                preCMakeBuild
+                postCMakeBuild
+                postCMakeInstall
+                postCTest
+            CALLBACK ${BEMAN_BASH}
+            ${BUILD_TELEMETRY_DIR}/telemetry.sh
         )
         message(
             DEBUG

--- a/cmake/beman-install-library.cmake
+++ b/cmake/beman-install-library.cmake
@@ -177,8 +177,7 @@ function(beman_install_library name)
             )
             foreach(_install_header_set IN LISTS _available_header_sets)
                 list(
-                    APPEND
-                    _install_header_set_args
+                    APPEND _install_header_set_args
                     FILE_SET
                     "${_install_header_set}"
                     COMPONENT

--- a/cmake/use-fetch-content.cmake
+++ b/cmake/use-fetch-content.cmake
@@ -15,8 +15,7 @@ message(TRACE "BemanExemplar_projectDir=\"${BemanExemplar_projectDir}\"")
 
 message(TRACE "BEMAN_EXEMPLAR_LOCKFILE=\"${BEMAN_EXEMPLAR_LOCKFILE}\"")
 file(
-    REAL_PATH
-    "${BEMAN_EXEMPLAR_LOCKFILE}"
+    REAL_PATH "${BEMAN_EXEMPLAR_LOCKFILE}"
     BemanExemplar_lockfile
     BASE_DIRECTORY "${BemanExemplar_projectDir}"
     EXPAND_TILDE
@@ -38,8 +37,7 @@ function(BemanExemplar_provideDependency method package_name)
 
     # Get the "dependencies" field and store it in BemanExemplar_dependenciesObj
     string(
-        JSON
-        BemanExemplar_dependenciesObj
+        JSON BemanExemplar_dependenciesObj
         ERROR_VARIABLE BemanExemplar_error
         GET "${BemanExemplar_rootObj}"
         "dependencies"
@@ -50,8 +48,7 @@ function(BemanExemplar_provideDependency method package_name)
 
     # Get the length of the libraries array and store it in BemanExemplar_dependenciesObj
     string(
-        JSON
-        BemanExemplar_numDependencies
+        JSON BemanExemplar_numDependencies
         ERROR_VARIABLE BemanExemplar_error
         LENGTH "${BemanExemplar_dependenciesObj}"
     )
@@ -73,8 +70,7 @@ function(BemanExemplar_provideDependency method package_name)
         # Get the dependency object at BemanExemplar_index
         # and store it in BemanExemplar_depObj
         string(
-            JSON
-            BemanExemplar_depObj
+            JSON BemanExemplar_depObj
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_dependenciesObj}"
             "${BemanExemplar_index}"
@@ -88,8 +84,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "name" field and store it in BemanExemplar_name
         string(
-            JSON
-            BemanExemplar_name
+            JSON BemanExemplar_name
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "name"
@@ -103,8 +98,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "package_name" field and store it in BemanExemplar_pkgName
         string(
-            JSON
-            BemanExemplar_pkgName
+            JSON BemanExemplar_pkgName
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "package_name"
@@ -118,8 +112,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "git_repository" field and store it in BemanExemplar_repo
         string(
-            JSON
-            BemanExemplar_repo
+            JSON BemanExemplar_repo
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "git_repository"
@@ -133,8 +126,7 @@ function(BemanExemplar_provideDependency method package_name)
 
         # Get the "git_tag" field and store it in BemanExemplar_tag
         string(
-            JSON
-            BemanExemplar_tag
+            JSON BemanExemplar_tag
             ERROR_VARIABLE BemanExemplar_error
             GET "${BemanExemplar_depObj}"
             "git_tag"
@@ -149,14 +141,12 @@ function(BemanExemplar_provideDependency method package_name)
         if(method STREQUAL "FIND_PACKAGE")
             if(package_name STREQUAL BemanExemplar_pkgName)
                 string(
-                    APPEND
-                    BemanExemplar_debug
+                    APPEND BemanExemplar_debug
                     "Redirecting find_package calls for ${BemanExemplar_pkgName} "
                     "to FetchContent logic.\n"
                 )
                 string(
-                    APPEND
-                    BemanExemplar_debug
+                    APPEND BemanExemplar_debug
                     "Fetching ${BemanExemplar_repo} at "
                     "${BemanExemplar_tag} according to ${BemanExemplar_lockfile}."
                 )
@@ -175,8 +165,7 @@ function(BemanExemplar_provideDependency method package_name)
                 # `include(Catch)` works.
                 if(BemanExemplar_pkgName STREQUAL "Catch2")
                     list(
-                        APPEND
-                        CMAKE_MODULE_PATH
+                        APPEND CMAKE_MODULE_PATH
                         "${${BemanExemplar_name}_SOURCE_DIR}/extras"
                     )
                     set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)


### PR DESCRIPTION
The gersemi project moved its pre-commit hook definition to a separate repository (BlankSpruce/gersemi-pre-commit) starting with v0.27.1, removing .pre-commit-hooks.yaml from the main repo.

This commit also bumps the codespell version.

See: https://github.com/BlankSpruce/gersemi/commit/e647b52384c05ddfc397664e73c822dacd5b0b75