### PR TITLE
Support cmake_args field in lockfile.json

### DIFF
--- a/cmake/use-fetch-content.cmake
+++ b/cmake/use-fetch-content.cmake
@@ -157,7 +157,50 @@ function(BemanExemplar_provideDependency method package_name)
                     GIT_TAG "${BemanExemplar_tag}"
                     EXCLUDE_FROM_ALL
                 )
-                set(INSTALL_GTEST OFF) # Disable GoogleTest installation
+
+                # Apply per-dependency cmake_args from the lockfile
+                string(
+                    JSON BemanExemplar_cmakeArgs
+                    ERROR_VARIABLE BemanExemplar_cmakeArgsError
+                    GET "${BemanExemplar_depObj}"
+                    "cmake_args"
+                )
+                if(NOT BemanExemplar_cmakeArgsError)
+                    string(
+                        JSON BemanExemplar_numCmakeArgs
+                        LENGTH "${BemanExemplar_cmakeArgs}"
+                    )
+                    if(BemanExemplar_numCmakeArgs GREATER 0)
+                        math(
+                            EXPR
+                            BemanExemplar_maxArgIndex
+                            "${BemanExemplar_numCmakeArgs} - 1"
+                        )
+                        foreach(
+                            BemanExemplar_argIndex
+                            RANGE "${BemanExemplar_maxArgIndex}"
+                        )
+                            string(
+                                JSON BemanExemplar_argKey
+                                MEMBER "${BemanExemplar_cmakeArgs}"
+                                "${BemanExemplar_argIndex}"
+                            )
+                            string(
+                                JSON BemanExemplar_argValue
+                                GET "${BemanExemplar_cmakeArgs}"
+                                "${BemanExemplar_argKey}"
+                            )
+                            message(
+                                DEBUG
+                                "Setting ${BemanExemplar_argKey}=${BemanExemplar_argValue} for ${BemanExemplar_name}"
+                            )
+                            set("${BemanExemplar_argKey}"
+                                "${BemanExemplar_argValue}"
+                            )
+                        endforeach()
+                    endif()
+                endif()
+
                 FetchContent_MakeAvailable("${BemanExemplar_name}")
 
                 # Catch2's CTest integration module isn't on CMAKE_MODULE_PATH


### PR DESCRIPTION
Before:

```json
{
  "dependencies": [
    {
      "name": "googletest",
      "package_name": "GTest",
      "git_repository": "https://github.com/google/googletest.git",
      "git_tag": "6910c9d9165801d8827d628cb72eb7ea9dd538c5"
    }
  ]
}
```

After:

```json
{
  "dependencies": [
    {
      "name": "googletest",
      "package_name": "GTest",
      "git_repository": "https://github.com/google/googletest.git",
      "git_tag": "6910c9d9165801d8827d628cb72eb7ea9dd538c5",
      "cmake_args": {
        "INSTALL_GTEST": "OFF"
      }
    }
  ]
}
```

And we remove the bespoke `set(INSTALL_GTEST OFF)` line from use-fetch-content.cmake.