### PR TITLE
Set BEMAN_USE_FETCH_CONTENT_ENABLED in use-fetch-content.cmake

### DIFF
--- a/cmake/use-fetch-content.cmake
+++ b/cmake/use-fetch-content.cmake
@@ -222,6 +222,8 @@ function(BemanExemplar_provideDependency method package_name)
     endforeach()
 endfunction()
 
+set(BEMAN_USE_FETCH_CONTENT_ENABLED ON)
+
 cmake_language(
     SET_DEPENDENCY_PROVIDER BemanExemplar_provideDependency
     SUPPORTED_METHODS FIND_PACKAGE


### PR DESCRIPTION
## Summary
- Set `BEMAN_USE_FETCH_CONTENT_ENABLED=ON` when the FetchContent dependency provider is active.
- Libraries with vcpkg-installable dependencies can check this flag to adjust their install logic (e.g., including FetchContent-provided targets in the export set vs. using `find_dependency`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)