### PR TITLE
Fix references to exemplar in cmake/use-fetch-content.cmake

### DIFF
--- a/cmake/use-fetch-content.cmake
+++ b/cmake/use-fetch-content.cmake
@@ -2,221 +2,192 @@ cmake_minimum_required(VERSION 3.24)
 
 include(FetchContent)
 
-if(NOT BEMAN_EXEMPLAR_LOCKFILE)
-    set(BEMAN_EXEMPLAR_LOCKFILE
+if(NOT BEMAN_LOCKFILE)
+    set(BEMAN_LOCKFILE
         "lockfile.json"
         CACHE FILEPATH
-        "Path to the dependency lockfile for the Beman Exemplar."
+        "Path to the dependency lockfile for the Beman project."
     )
 endif()
 
-set(BemanExemplar_projectDir "${CMAKE_CURRENT_LIST_DIR}/../..")
-message(TRACE "BemanExemplar_projectDir=\"${BemanExemplar_projectDir}\"")
+set(Beman_projectDir "${CMAKE_CURRENT_LIST_DIR}/../..")
+message(TRACE "Beman_projectDir=\"${Beman_projectDir}\"")
 
-message(TRACE "BEMAN_EXEMPLAR_LOCKFILE=\"${BEMAN_EXEMPLAR_LOCKFILE}\"")
+message(TRACE "BEMAN_LOCKFILE=\"${BEMAN_LOCKFILE}\"")
 file(
-    REAL_PATH "${BEMAN_EXEMPLAR_LOCKFILE}"
-    BemanExemplar_lockfile
-    BASE_DIRECTORY "${BemanExemplar_projectDir}"
+    REAL_PATH "${BEMAN_LOCKFILE}"
+    Beman_lockfile
+    BASE_DIRECTORY "${Beman_projectDir}"
     EXPAND_TILDE
 )
-message(DEBUG "Using lockfile: \"${BemanExemplar_lockfile}\"")
+message(DEBUG "Using lockfile: \"${Beman_lockfile}\"")
 
 # Force CMake to reconfigure the project if the lockfile changes
 set_property(
-    DIRECTORY "${BemanExemplar_projectDir}"
+    DIRECTORY "${Beman_projectDir}"
     APPEND
-    PROPERTY CMAKE_CONFIGURE_DEPENDS "${BemanExemplar_lockfile}"
+    PROPERTY CMAKE_CONFIGURE_DEPENDS "${Beman_lockfile}"
 )
 
 # For more on the protocol for this function, see:
 # https://cmake.org/cmake/help/latest/command/cmake_language.html#provider-commands
-function(BemanExemplar_provideDependency method package_name)
+function(Beman_provideDependency method package_name)
     # Read the lockfile
-    file(READ "${BemanExemplar_lockfile}" BemanExemplar_rootObj)
+    file(READ "${Beman_lockfile}" Beman_rootObj)
 
-    # Get the "dependencies" field and store it in BemanExemplar_dependenciesObj
+    # Get the "dependencies" field and store it in Beman_dependenciesObj
     string(
-        JSON BemanExemplar_dependenciesObj
-        ERROR_VARIABLE BemanExemplar_error
-        GET "${BemanExemplar_rootObj}"
+        JSON Beman_dependenciesObj
+        ERROR_VARIABLE Beman_error
+        GET "${Beman_rootObj}"
         "dependencies"
     )
-    if(BemanExemplar_error)
-        message(FATAL_ERROR "${BemanExemplar_lockfile}: ${BemanExemplar_error}")
+    if(Beman_error)
+        message(FATAL_ERROR "${Beman_lockfile}: ${Beman_error}")
     endif()
 
-    # Get the length of the libraries array and store it in BemanExemplar_dependenciesObj
+    # Get the length of the libraries array and store it in Beman_dependenciesObj
     string(
-        JSON BemanExemplar_numDependencies
-        ERROR_VARIABLE BemanExemplar_error
-        LENGTH "${BemanExemplar_dependenciesObj}"
+        JSON Beman_numDependencies
+        ERROR_VARIABLE Beman_error
+        LENGTH "${Beman_dependenciesObj}"
     )
-    if(BemanExemplar_error)
-        message(FATAL_ERROR "${BemanExemplar_lockfile}: ${BemanExemplar_error}")
+    if(Beman_error)
+        message(FATAL_ERROR "${Beman_lockfile}: ${Beman_error}")
     endif()
 
-    if(BemanExemplar_numDependencies EQUAL 0)
+    if(Beman_numDependencies EQUAL 0)
         return()
     endif()
 
     # Loop over each dependency object
-    math(EXPR BemanExemplar_maxIndex "${BemanExemplar_numDependencies} - 1")
-    foreach(BemanExemplar_index RANGE "${BemanExemplar_maxIndex}")
-        set(BemanExemplar_errorPrefix
-            "${BemanExemplar_lockfile}, dependency ${BemanExemplar_index}"
-        )
+    math(EXPR Beman_maxIndex "${Beman_numDependencies} - 1")
+    foreach(Beman_index RANGE "${Beman_maxIndex}")
+        set(Beman_errorPrefix "${Beman_lockfile}, dependency ${Beman_index}")
 
-        # Get the dependency object at BemanExemplar_index
-        # and store it in BemanExemplar_depObj
+        # Get the dependency object at Beman_index
+        # and store it in Beman_depObj
         string(
-            JSON BemanExemplar_depObj
-            ERROR_VARIABLE BemanExemplar_error
-            GET "${BemanExemplar_dependenciesObj}"
-            "${BemanExemplar_index}"
+            JSON Beman_depObj
+            ERROR_VARIABLE Beman_error
+            GET "${Beman_dependenciesObj}"
+            "${Beman_index}"
         )
-        if(BemanExemplar_error)
-            message(
-                FATAL_ERROR
-                "${BemanExemplar_errorPrefix}: ${BemanExemplar_error}"
-            )
+        if(Beman_error)
+            message(FATAL_ERROR "${Beman_errorPrefix}: ${Beman_error}")
         endif()
 
-        # Get the "name" field and store it in BemanExemplar_name
+        # Get the "name" field and store it in Beman_name
         string(
-            JSON BemanExemplar_name
-            ERROR_VARIABLE BemanExemplar_error
-            GET "${BemanExemplar_depObj}"
+            JSON Beman_name
+            ERROR_VARIABLE Beman_error
+            GET "${Beman_depObj}"
             "name"
         )
-        if(BemanExemplar_error)
-            message(
-                FATAL_ERROR
-                "${BemanExemplar_errorPrefix}: ${BemanExemplar_error}"
-            )
+        if(Beman_error)
+            message(FATAL_ERROR "${Beman_errorPrefix}: ${Beman_error}")
         endif()
 
-        # Get the "package_name" field and store it in BemanExemplar_pkgName
+        # Get the "package_name" field and store it in Beman_pkgName
         string(
-            JSON BemanExemplar_pkgName
-            ERROR_VARIABLE BemanExemplar_error
-            GET "${BemanExemplar_depObj}"
+            JSON Beman_pkgName
+            ERROR_VARIABLE Beman_error
+            GET "${Beman_depObj}"
             "package_name"
         )
-        if(BemanExemplar_error)
-            message(
-                FATAL_ERROR
-                "${BemanExemplar_errorPrefix}: ${BemanExemplar_error}"
-            )
+        if(Beman_error)
+            message(FATAL_ERROR "${Beman_errorPrefix}: ${Beman_error}")
         endif()
 
-        # Get the "git_repository" field and store it in BemanExemplar_repo
+        # Get the "git_repository" field and store it in Beman_repo
         string(
-            JSON BemanExemplar_repo
-            ERROR_VARIABLE BemanExemplar_error
-            GET "${BemanExemplar_depObj}"
+            JSON Beman_repo
+            ERROR_VARIABLE Beman_error
+            GET "${Beman_depObj}"
             "git_repository"
         )
-        if(BemanExemplar_error)
-            message(
-                FATAL_ERROR
-                "${BemanExemplar_errorPrefix}: ${BemanExemplar_error}"
-            )
+        if(Beman_error)
+            message(FATAL_ERROR "${Beman_errorPrefix}: ${Beman_error}")
         endif()
 
-        # Get the "git_tag" field and store it in BemanExemplar_tag
+        # Get the "git_tag" field and store it in Beman_tag
         string(
-            JSON BemanExemplar_tag
-            ERROR_VARIABLE BemanExemplar_error
-            GET "${BemanExemplar_depObj}"
+            JSON Beman_tag
+            ERROR_VARIABLE Beman_error
+            GET "${Beman_depObj}"
             "git_tag"
         )
-        if(BemanExemplar_error)
-            message(
-                FATAL_ERROR
-                "${BemanExemplar_errorPrefix}: ${BemanExemplar_error}"
-            )
+        if(Beman_error)
+            message(FATAL_ERROR "${Beman_errorPrefix}: ${Beman_error}")
         endif()
 
         if(method STREQUAL "FIND_PACKAGE")
-            if(package_name STREQUAL BemanExemplar_pkgName)
+            if(package_name STREQUAL Beman_pkgName)
                 string(
-                    APPEND BemanExemplar_debug
-                    "Redirecting find_package calls for ${BemanExemplar_pkgName} "
+                    APPEND Beman_debug
+                    "Redirecting find_package calls for ${Beman_pkgName} "
                     "to FetchContent logic.\n"
                 )
                 string(
-                    APPEND BemanExemplar_debug
-                    "Fetching ${BemanExemplar_repo} at "
-                    "${BemanExemplar_tag} according to ${BemanExemplar_lockfile}."
+                    APPEND Beman_debug
+                    "Fetching ${Beman_repo} at "
+                    "${Beman_tag} according to ${Beman_lockfile}."
                 )
-                message(DEBUG "${BemanExemplar_debug}")
+                message(DEBUG "${Beman_debug}")
                 FetchContent_Declare(
-                    "${BemanExemplar_name}"
-                    GIT_REPOSITORY "${BemanExemplar_repo}"
-                    GIT_TAG "${BemanExemplar_tag}"
+                    "${Beman_name}"
+                    GIT_REPOSITORY "${Beman_repo}"
+                    GIT_TAG "${Beman_tag}"
                     EXCLUDE_FROM_ALL
                 )
 
                 # Apply per-dependency cmake_args from the lockfile
                 string(
-                    JSON BemanExemplar_cmakeArgs
-                    ERROR_VARIABLE BemanExemplar_cmakeArgsError
-                    GET "${BemanExemplar_depObj}"
+                    JSON Beman_cmakeArgs
+                    ERROR_VARIABLE Beman_cmakeArgsError
+                    GET "${Beman_depObj}"
                     "cmake_args"
                 )
-                if(NOT BemanExemplar_cmakeArgsError)
-                    string(
-                        JSON BemanExemplar_numCmakeArgs
-                        LENGTH "${BemanExemplar_cmakeArgs}"
-                    )
-                    if(BemanExemplar_numCmakeArgs GREATER 0)
-                        math(
-                            EXPR
-                            BemanExemplar_maxArgIndex
-                            "${BemanExemplar_numCmakeArgs} - 1"
-                        )
-                        foreach(
-                            BemanExemplar_argIndex
-                            RANGE "${BemanExemplar_maxArgIndex}"
-                        )
+                if(NOT Beman_cmakeArgsError)
+                    string(JSON Beman_numCmakeArgs LENGTH "${Beman_cmakeArgs}")
+                    if(Beman_numCmakeArgs GREATER 0)
+                        math(EXPR Beman_maxArgIndex "${Beman_numCmakeArgs} - 1")
+                        foreach(Beman_argIndex RANGE "${Beman_maxArgIndex}")
                             string(
-                                JSON BemanExemplar_argKey
-                                MEMBER "${BemanExemplar_cmakeArgs}"
-                                "${BemanExemplar_argIndex}"
+                                JSON Beman_argKey
+                                MEMBER "${Beman_cmakeArgs}"
+                                "${Beman_argIndex}"
                             )
                             string(
-                                JSON BemanExemplar_argValue
-                                GET "${BemanExemplar_cmakeArgs}"
-                                "${BemanExemplar_argKey}"
+                                JSON Beman_argValue
+                                GET "${Beman_cmakeArgs}"
+                                "${Beman_argKey}"
                             )
                             message(
                                 DEBUG
-                                "Setting ${BemanExemplar_argKey}=${BemanExemplar_argValue} for ${BemanExemplar_name}"
+                                "Setting ${Beman_argKey}=${Beman_argValue} for ${Beman_name}"
                             )
-                            set("${BemanExemplar_argKey}"
-                                "${BemanExemplar_argValue}"
-                            )
+                            set("${Beman_argKey}" "${Beman_argValue}")
                         endforeach()
                     endif()
                 endif()
 
-                FetchContent_MakeAvailable("${BemanExemplar_name}")
+                FetchContent_MakeAvailable("${Beman_name}")
 
                 # Catch2's CTest integration module isn't on CMAKE_MODULE_PATH
                 # when brought in via FetchContent. Add it so that
                 # `include(Catch)` works.
-                if(BemanExemplar_pkgName STREQUAL "Catch2")
+                if(Beman_pkgName STREQUAL "Catch2")
                     list(
                         APPEND CMAKE_MODULE_PATH
-                        "${${BemanExemplar_name}_SOURCE_DIR}/extras"
+                        "${${Beman_name}_SOURCE_DIR}/extras"
                     )
                     set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" PARENT_SCOPE)
                 endif()
 
                 # Important! <PackageName>_FOUND tells CMake that `find_package` is
                 # not needed for this package anymore
-                set("${BemanExemplar_pkgName}_FOUND" TRUE PARENT_SCOPE)
+                set("${Beman_pkgName}_FOUND" TRUE PARENT_SCOPE)
             endif()
         endif()
     endforeach()
@@ -225,7 +196,7 @@ endfunction()
 set(BEMAN_USE_FETCH_CONTENT_ENABLED ON)
 
 cmake_language(
-    SET_DEPENDENCY_PROVIDER BemanExemplar_provideDependency
+    SET_DEPENDENCY_PROVIDER Beman_provideDependency
     SUPPORTED_METHODS FIND_PACKAGE
 )
 


### PR DESCRIPTION
This file was originally exclusively part of exemplar, but was moved into infra without updating all of the uses of "exemplar" in its variable names.

Fixes: #4