### PR TITLE
Relicence llvm-libc++-toolchain.cmake under Apache

### DIFF
--- a/cmake/llvm-libc++-toolchain.cmake
+++ b/cmake/llvm-libc++-toolchain.cmake
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSL-1.0
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # This toolchain file is not meant to be used directly,
 # but to be invoked by CMake preset and GitHub CI.


### PR DESCRIPTION
This was BSL because it was copied in from beman.utf_view, which is under BSL. I'm the only contributor to this file so I'm adjusting the SPDX identifier.