### PR TITLE
Fix beman_install_library() function name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository is intended to be used as a beman-submodule in other Beman repos
 #### `beman_install_library`
 
 The CMake modules in this repository are intended to be used by Beman libraries. Use the
-`beman_add_install_library_config()` function to install your library, along with header
+`beman_install_library()` function to install your library, along with header
 files, any metadata files, and a CMake config file for `find_package()` support.
 
 ```cmake


### PR DESCRIPTION
This was missed when a09c5ce64bdb8df269ab2d745f8c39530a8b37ed updated this function.