### PR TITLE
Replace find_package(beman-install-library) with existing practice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ add_library(beman::something ALIAS beman.something)
 
 # ... configure your target as needed ...
 
-find_package(beman-install-library REQUIRED)
+include(infra/cmake/beman-install-library.cmake)
 beman_install_library(beman.something)
 ```
 


### PR DESCRIPTION
Since
https://github.com/bemanproject/exemplar/commit/df40a6da471533585e866826b69a4e2f8ffbecdb, exemplar simply includes the file rather than using find_package.