### PR TITLE
Add missing license identifiers

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 name: Lint Check (pre-commit)
 
 on:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/cmake/BuildTelemetry.cmake
+++ b/cmake/BuildTelemetry.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 include_guard(GLOBAL)
 
 include(${CMAKE_CURRENT_LIST_DIR}/BuildTelemetryConfig.cmake)

--- a/cmake/BuildTelemetryConfig.cmake
+++ b/cmake/BuildTelemetryConfig.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 include_guard(GLOBAL)
 
 set(BUILD_TELEMETRY_DIR ${CMAKE_CURRENT_LIST_DIR})

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,5 +1,5 @@
-# cmake/Config.cmake.in -*-makefile-*-
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# cmake/Config.cmake.in -*-makefile-*-
 
 include(CMakeFindDependencyMacro)
 

--- a/cmake/telemetry.sh
+++ b/cmake/telemetry.sh
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #!/usr/bin/env bash
 
 set -o nounset

--- a/cmake/use-fetch-content.cmake
+++ b/cmake/use-fetch-content.cmake
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 cmake_minimum_required(VERSION 3.24)
 
 include(FetchContent)


### PR DESCRIPTION
In order to sync with exemplar, which has now implemented `file.license_id` from the beman standard.
bemanproject/exemplar#375