### PR TITLE
Install C++ module sources under share/, not lib/cmake/

### DIFF
--- a/cmake/beman-install-library.cmake
+++ b/cmake/beman-install-library.cmake
@@ -122,7 +122,9 @@ function(beman_install_library name)
     endif()
 
     if(NOT BEMAN_INSTALL_DESTINATION)
-        set(BEMAN_INSTALL_DESTINATION "${_config_install_dir}/modules")
+        set(BEMAN_INSTALL_DESTINATION
+            "${CMAKE_INSTALL_DATADIR}/${name}/modules"
+        )
     endif()
 
     string(REPLACE "beman." "" install_component_name "${name}")
@@ -210,7 +212,7 @@ function(beman_install_library name)
                 # NOTE: There's currently no convention for this location! CK
                 CXX_MODULES_BMI
                     DESTINATION
-                        ${_config_install_dir}/bmi-${CMAKE_CXX_COMPILER_ID}_$<CONFIG>
+                        ${CMAKE_INSTALL_DATADIR}/${name}/bmi-${CMAKE_CXX_COMPILER_ID}_$<CONFIG>
                     COMPONENT "${install_component_name}_Development"
             )
         else()


### PR DESCRIPTION
beman_install_library previously installed CXX_MODULES file sets (and CXX_MODULES_BMI) under ${CMAKE_INSTALL_LIBDIR}/cmake/${name}/modules, i.e. directly inside the same directory used for the CMake config package. For non-vcpkg installs this is harmless, but it breaks under vcpkg's vcpkg_cmake_config_fixup.

vcpkg_cmake_config_fixup, when CONFIG_PATH is lib/cmake/<port>, does:

    file(GLOB files "${release_config}/*")
    file(COPY ${files} DESTINATION "${release_share}")
    file(REMOVE_RECURSE "${release_config}")

The GLOB matches both *.cmake files and the modules/ subdirectory; the COPY relocates them into share/<port>/; and the REMOVE_RECURSE then deletes the entire lib/cmake/<port>/ tree. The fixup adjusts _IMPORT_PREFIX in the moved *.cmake files but does not rewrite any ${_IMPORT_PREFIX}/lib/cmake/<port>/... substrings inside them, so the exported targets file still references module sources at their original (now-deleted) install paths. Consumers calling find_package hit "Cannot find source file" the moment the imported target's target_sources(... FILE_SET CXX_MODULES FILES ...) is processed.

Switching the destination to ${CMAKE_INSTALL_DATADIR}/${name}/modules (and the same for the BMI install) places module sources at their post-fixup location to begin with, so the move never moves them and the absolute paths baked into the targets file remain valid. For non-vcpkg installs the behavior is equivalent: find_package still locates the config in lib/cmake/<name>/ and resolves ${_IMPORT_PREFIX}/share/<name>/modules/... against the same prefix.

The CXX_MODULES_BMI change is a latent fix; BMI installation isn't enabled by default in this configuration but would have hit the same failure mode the moment it was.