### PR TITLE
Remove @neatudarius from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ednolan @neatudarius @rishyak @wusatosi @JeffGarland
+* @ednolan @rishyak @wusatosi @JeffGarland


### PR DESCRIPTION
Removes @neatudarius as code owner as they are no longer actively maintaining this repository.
